### PR TITLE
Change directory where go.mod resides before running go test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,8 @@ jobs:
       - run:
           name: test
           command: |
-            go test -v ./app/...
+            cd app # go.modが置いてあるディレクトリに移動して`go test`する(そうしないとgo modのinitializeが走り面倒なことに)
+            go test -v ./...
       - save_cache:
           key: go-mod-{{ checksum "app/go.sum" }}
           paths:


### PR DESCRIPTION
# 目的
* go testがうまくまわってなかった

```
#!/bin/bash -eo pipefail
go test -v ./app/...
go: creating new go.mod: module github.com/sxarp/eks-terraform-ci-sample
go: finding github.com/sxarp/eks-terraform-ci-sample/app latest
go: downloading github.com/sxarp/eks-terraform-ci-sample/app v0.0.0-20190714115355-e2b5dce5587d
go: extracting github.com/sxarp/eks-terraform-ci-sample/app v0.0.0-20190714115355-e2b5dce5587d
=== RUN   TestHandler
--- PASS: TestHandler (0.00s)
=== RUN   TestSlowHandler
--- PASS: TestSlowHandler (0.31s)
PASS
ok  	github.com/sxarp/eks-terraform-ci-sample/app	0.309s
```
https://circleci.com/gh/sxarp/eks-terraform-ci-sample/378

`go: creating new go.mod`されて、`go: finding github.com/sxarp/eks-terraform-ci-sample/app latest`されて、現時点のアプリのコードが参照されていない


# 確認

```sh
#!/bin/bash -eo pipefail
cd app # go.modが置いてあるディレクトリに移動して`go test`する(そうしないとgo modのinitializeが走り面倒なことに)
go test -v ./...
=== RUN   TestHandler
--- PASS: TestHandler (0.00s)
=== RUN   TestSlowHandler
--- PASS: TestSlowHandler (0.31s)
PASS
ok  	github.com/sxarp/eks-terraform-ci-sample/app	0.308s
```

https://circleci.com/gh/sxarp/eks-terraform-ci-sample/440

